### PR TITLE
graf version 2.4 conda package

### DIFF
--- a/recipes/graf_v2.4/build.sh
+++ b/recipes/graf_v2.4/build.sh
@@ -1,0 +1,8 @@
+mkdir $PREFIX/bin
+cp graf $PREFIX/bin
+cp graf_dups $PREFIX/bin
+sed 's/\/usr\/local\/bin\/perl/\/usr\/bin\/env perl/' PlotPopulations.pl > $PREFIX/bin/PlotPopulations.pl
+sed 's/\/usr\/local\/bin\/perl/\/usr\/bin\/env perl/' PlotGraf.pl > $PREFIX/bin/PlotGraf.pl
+mkdir $PREFIX/share
+mkdir $PREFIX/share/graf
+cp -R data/* $PREFIX/share/graf

--- a/recipes/graf_v2.4/meta.yaml
+++ b/recipes/graf_v2.4/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: graf
+  version: "2.4"
+
+source:
+  url: "http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/GetZip.cgi?zip_name=GRAF_files.zip"
+
+requirements:
+  run:
+  - perl-cgi
+  - perl-carp
+  - perl-gd
+  - perl-gdgraph
+  - perl-gdtextutil
+
+about:
+  home: https://github.com/ncbi/graf


### PR DESCRIPTION
Created conda build scripts (build.sh and meta.yaml) for package with updated version of graf2.4. 

Corresponding graf-2.4-0.tar.bz2 is also committed. 